### PR TITLE
argparse updates

### DIFF
--- a/netpuppy/__main__.py
+++ b/netpuppy/__main__.py
@@ -23,22 +23,25 @@ def main() -> None:
         description="Launch a puppy to sneef and fetch data for you!",
         epilog="Tell netpuppy he was a good boi.",
     )
-    
-    
+
     # Add arguments as individual subparsed groups - this gains us the ability to easily extend our 'commands' in the future
-    # as well as fine grained control over the arguments for each command. This does come with a slight drawback of 
+    # as well as fine grained control over the arguments for each command. This does come with a slight drawback of
     # having to repeat shared argument definitions (like port), but seems worth the tradeoff
     subparsers = parser.add_subparsers()
 
     sp = subparsers.add_parser("connect", help="Connect to a host (Client Mode)")
-    sp.set_defaults(cmd = "connect")
-    sp.add_argument("host_ip", help="Host IP Address", type=str) # required input
-    sp.add_argument("port", help="Host Port", type=network_port, nargs="?", default="44440") # optional with default
+    sp.set_defaults(cmd="connect")
+    sp.add_argument("host_ip", help="Host IP Address", type=str)  # required input
+    sp.add_argument(
+        "port", help="Host Port", type=network_port, nargs="?", default="44440"
+    )  # optional with default
 
     sp = subparsers.add_parser("listen", help="Listen on a port (Server Mode)")
-    sp.set_defaults(cmd = "listen")
-    sp.set_defaults(host_ip = "0.0.0.0") # default to all interfaces
-    sp.add_argument("port", help="Listen Port", type=network_port, nargs="?", default="44440") # optional with default
+    sp.set_defaults(cmd="listen")
+    sp.set_defaults(host_ip="0.0.0.0")  # default to all interfaces
+    sp.add_argument(
+        "port", help="Listen Port", type=network_port, nargs="?", default="44440"
+    )  # optional with default
 
     # Get the list of arguments:
     try:

--- a/netpuppy/utils.py
+++ b/netpuppy/utils.py
@@ -8,8 +8,8 @@ TrshPuppy brings you...
 
 |8PPPPe                  ___      .++.
 |8    |8 |eeee |eeeee __/_, `.  .'    `. .
-|8e   |8 |8      |8   \_,  | \_'  /   )`-')
-|88   |8 |8eee   |8e   U ) `-`    \  ((`\"`
+|8e   |8 |8      |8   \\_,  | \\_'  /   )`-')
+|88   |8 |8eee   |8e   U ) `-`    \\  ((`\"`
 |88   |8 |88     |88   ___Y  ,    .'7 /| 
 |88___|8_|88ee___|88__(_,___/___.'_(_/_/_
 
@@ -47,7 +47,7 @@ def user_selection_update(h: str, p: str, c: str) -> str:
         update = """
     .-.  *sneef sneef*
    / (_   
-  ( "  6\___o   |Host: {host}
+  ( "  6\\___o   |Host: {host}
   /  (  ___/    |Port: {port}
  /     /  U     |Mode: {mode}
     """.format(

--- a/netpuppy/utils.py
+++ b/netpuppy/utils.py
@@ -27,10 +27,10 @@ TrshPuppy brings you...
     return banner
 
 
-def user_selection_update(h: str, p: str, l: str) -> str:
+def user_selection_update(h: str, p: str, c: str) -> str:
     update: str = ""
 
-    if not l:
+    if c == "connect":
         update = """
            bork!
       __  /  
@@ -47,10 +47,11 @@ def user_selection_update(h: str, p: str, l: str) -> str:
         update = """
     .-.  *sneef sneef*
    / (_   
-  ( "  6\___o   |Host: localhost
+  ( "  6\___o   |Host: {host}
   /  (  ___/    |Port: {port}
  /     /  U     |Mode: {mode}
     """.format(
+            host=h,
             port=p,
             mode="Server",
         )


### PR DESCRIPTION
* Replace basic exclusive group with subparsers so that we can define argument groups.
* host and port parameters are now positional by default - no need to specify -H or -p. `netpuppy connect 1.2.3.4 [port]` and `netpuppy listen [port]` are available, and port has a default of 44440 in both definitions, making the minimum calls `netpuppy listen` and `netpuppy connect 1.2.3.4` valid.
* Slight flow control change to use the 'args.cmd' parameter when determining flow, instead of the presence of args.listen or args.host_ip.