### PR TITLE
C-Macros for build errors for FFI code (pty)

### DIFF
--- a/pkg/pty/ptsname.go
+++ b/pkg/pty/ptsname.go
@@ -1,5 +1,10 @@
 package pty
 
+// #ifdef __linux__
+// #define _GNU_SOURCE
+// #else
+// #define _XOPEN_SOURCE 600
+// #endif
 // #include <stdlib.h>
 // #include <stdint.h>
 // #include <stdio.h>


### PR DESCRIPTION
This fixes the build error on linux 
If we define the platform via C-Macros it goes away

```
pkg/pty/ptsname.go: In function 'getPTSn':
pkg/pty/ptsname.go:17:16: error: implicit declaration of function 'ptsname_r' [-Wimplicit-function-declaration]
   17 | //         err = ptsname_r(fd, buf, len);
```

https://man7.org/linux/man-pages/man7/feature_test_macros.7.html